### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -16,7 +16,7 @@ def purge_redis_cache(cache_redis_url, tags):
 
 def purge_fastly_tags(domain, api_key, service_id, tags):
     session = requests.session()
-    headers = {"X-Fastly-Key": api_key, "Accept": "application/json"}
+    headers = {"Fastly-Key": api_key, "Accept": "application/json"}
 
     all_tags = set(tags)
     purges = {}


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
